### PR TITLE
Bump version for security rebuild.

### DIFF
--- a/docker_push.sh
+++ b/docker_push.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-VERSION=1.2.2
+VERSION="1.2.4"
 
-docker buildx build --platform linux/amd64,linux/arm64/v8 --push -t 064061306967.dkr.ecr.us-west-2.amazonaws.com/acceptto/local-reverse-geocoder:$VERSION .
+docker buildx build --sbom=false --provenance=false --platform linux/amd64,linux/arm64/v8 --push -t 064061306967.dkr.ecr.us-west-2.amazonaws.com/acceptto/local-reverse-geocoder:$VERSION .


### PR DESCRIPTION
Also prevent zero byte artifacts on ECR.