### PR TITLE
ECT-1803 Security Updates

### DIFF
--- a/docker_push.sh
+++ b/docker_push.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
-VERSION="1.2.5"
+set -e
+
+VERSION="$(git describe --tags --match 'v*')"  # Get version tag from git
+VERSION=${VERSION#v}                           # Remove leading 'v'
+
+read -p "This action will build and publish docker image version $VERSION (this will automatically proceed in 15 seconds)" -t 15
 
 docker buildx build --sbom=false --provenance=false --platform linux/amd64,linux/arm64/v8 --push -t 064061306967.dkr.ecr.us-west-2.amazonaws.com/acceptto/local-reverse-geocoder:$VERSION .


### PR DESCRIPTION
Pull docker tag from git

* Show version about to be pushed to allow time to cancel if wrong version is determined.
  *  Wait 15 seconds (or for user input) before proceeding (so automated tools don't block).